### PR TITLE
Add Notion API client and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ __pycache__/
 # ---- Date-stamped data folders (22_May_2025, 03_Jun_2024, …) ----
 # Two digits, underscore, three-letter month, underscore, four digits, trailing slash
 **/[0-3][0-9]_[A-Z][a-z][a-z]_[0-9][0-9][0-9][0-9]/
+
+# Secrets
+secret.txt
+db.txt

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+from src.database import get_schema, query_database
+
+
+def main() -> None:
+    schema = get_schema()
+    keys = list(schema.get("properties", {}).keys())
+    print("Schema keys:", keys)
+
+    rows = query_database()
+    print("Rows fetched:", len(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/client.py
+++ b/src/client.py
@@ -1,0 +1,22 @@
+import time
+import requests
+from typing import Any, Dict
+
+BASE_URL = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+
+
+def request(method: str, path: str, token: str, **kwargs: Any) -> Dict[str, Any]:
+    url = f"{BASE_URL}{path}"
+    headers = kwargs.pop("headers", {})
+    headers.setdefault("Authorization", f"Bearer {token}")
+    headers.setdefault("Notion-Version", NOTION_VERSION)
+    while True:
+        resp = requests.request(method, url, headers=headers, **kwargs)
+        if resp.status_code == 429:
+            wait = int(resp.headers.get("Retry-After", "1"))
+            time.sleep(wait)
+            continue
+        if not resp.ok:
+            raise Exception(f"Notion API error {resp.status_code}: {resp.text}")
+        return resp.json()

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,16 @@
+import os
+
+
+def _read_file(path: str) -> str | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+
+NOTION_TOKEN = os.getenv("NOTION_TOKEN") or _read_file("secret.txt")
+NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID") or _read_file("db.txt")
+
+if not NOTION_TOKEN or not NOTION_DATABASE_ID:
+    raise RuntimeError("Missing Notion credentials")

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, List
+
+from .config import NOTION_TOKEN, NOTION_DATABASE_ID
+from .client import request
+
+
+def get_schema(db_id: str | None = None, token: str | None = None) -> Dict[str, Any]:
+    db_id = db_id or NOTION_DATABASE_ID
+    token = token or NOTION_TOKEN
+    return request("GET", f"/databases/{db_id}", token)
+
+
+def query_database(
+    db_id: str | None = None,
+    token: str | None = None,
+    **payload: Any,
+) -> List[Dict[str, Any]]:
+    db_id = db_id or NOTION_DATABASE_ID
+    token = token or NOTION_TOKEN
+    results: List[Dict[str, Any]] = []
+    next_cursor: str | None = None
+    while True:
+        body = dict(payload)
+        if next_cursor:
+            body["start_cursor"] = next_cursor
+        resp = request("POST", f"/databases/{db_id}/query", token, json=body)
+        results.extend(resp.get("results", []))
+        if not resp.get("has_more"):
+            break
+        next_cursor = resp.get("next_cursor")
+    return results


### PR DESCRIPTION
## Summary
- ignore secret and database files
- add configuration loader for Notion credentials
- implement simple HTTP client with rate limit handling
- provide helpers for querying a Notion database
- add demo script that prints database schema and number of rows

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install requests`
- `python main.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684210e9a89883309f061acbb2559815