### PR TITLE
Enable automatic Notion fetch on app startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ python src/report.py 04_Jun_2025
 
 ### Web Application
 
-A simple Flask web app is available for interactive exploration. It automatically loads the most recent dated folder in `data/` and builds an SQLite database along with all graphs.
+A simple Flask web app is available for interactive exploration. On startup it will
+fetch the latest data from Notion if a folder for the current day does not
+already exist. The app then loads the most recent dated folder in `data/` and
+builds an SQLite database along with all graphs.
 
 Run it with:
 

--- a/app/app.py
+++ b/app/app.py
@@ -10,6 +10,7 @@ import plotly.offline as pyo
 BASE_DIR = os.path.dirname(__file__)
 sys.path.append(os.path.join(BASE_DIR, '..', 'src'))
 
+from database import export_database_csv
 from report import (
     analyze_tasks,
     plot_time_to_completion_histogram,
@@ -37,6 +38,15 @@ df_global = None
 analysis_global = None
 
 
+def _ensure_today_folder() -> None:
+    """Fetch data from Notion if today's folder is missing."""
+    today = datetime.now().strftime('%d_%b_%Y')
+    folder_path = os.path.join(DATA_DIR, today)
+    csv_files = glob.glob(os.path.join(folder_path, '*_all.csv'))
+    if not csv_files:
+        export_database_csv(folder_path)
+
+
 def _latest_csv():
     folders = [f for f in os.listdir(DATA_DIR) if os.path.isdir(os.path.join(DATA_DIR, f))]
     if not folders:
@@ -58,6 +68,7 @@ def _latest_csv():
 
 def _load_data():
     global df_global, analysis_global
+    _ensure_today_folder()
     csv_path, folder_path = _latest_csv()
     df, analysis = analyze_tasks(csv_path)
 

--- a/src/database.py
+++ b/src/database.py
@@ -1,4 +1,6 @@
 from typing import Any, Dict, List
+import os
+import pandas as pd
 
 from .config import NOTION_TOKEN, NOTION_DATABASE_ID
 from .client import request
@@ -29,3 +31,49 @@ def query_database(
             break
         next_cursor = resp.get("next_cursor")
     return results
+
+
+def _extract_value(prop: Dict[str, Any]) -> Any:
+    """Return a simplified Python value for a Notion property."""
+    t = prop.get("type")
+    value = prop.get(t)
+    if t in ("title", "rich_text"):
+        return "".join(part.get("plain_text", "") for part in value)
+    if t in ("select", "status"):
+        return value.get("name") if value else None
+    if t == "multi_select":
+        return ";".join(opt.get("name", "") for opt in value)
+    if t == "people":
+        return ";".join(p.get("name", "") for p in value)
+    if t == "date":
+        return value.get("start") if value else None
+    return value
+
+
+def query_database_dataframe(
+    db_id: str | None = None,
+    token: str | None = None,
+    **payload: Any,
+) -> pd.DataFrame:
+    """Return the entire Notion database as a pandas ``DataFrame``."""
+    pages = query_database(db_id=db_id, token=token, **payload)
+    rows: List[Dict[str, Any]] = []
+    for page in pages:
+        row: Dict[str, Any] = {
+            "id": page.get("id"),
+            "Created time": page.get("created_time"),
+            "Last edited": page.get("last_edited_time"),
+        }
+        for name, prop in page.get("properties", {}).items():
+            row[name] = _extract_value(prop)
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def export_database_csv(folder_path: str, filename: str = "notion_all.csv") -> str:
+    """Fetch the database and save as a CSV in ``folder_path``."""
+    os.makedirs(folder_path, exist_ok=True)
+    df = query_database_dataframe()
+    csv_path = os.path.join(folder_path, filename)
+    df.to_csv(csv_path, index=False)
+    return csv_path


### PR DESCRIPTION
## Summary
- fetch the Notion database when starting the app if today's folder doesn't exist
- support converting Notion pages into a dataframe and CSV export
- document automatic fetch behavior in README

## Testing
- `python -m py_compile src/database.py app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684215406c2c83309d79ccf29715af76