### PR TITLE
Add weekly task flow interactive view

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ python app/app.py
 Open `http://localhost:5000` in your browser to view the dashboard.
 
 All graphs are saved under `app/static/img`.
+The interactive section now includes a weekly task flow view with a year selector.

--- a/app/app.py
+++ b/app/app.py
@@ -27,6 +27,7 @@ from src.report import (
     plot_liberal_stuff_done_heatmaps,
     interactive_ttc_histogram,
     interactive_monthly_task_flow,
+    interactive_weekly_task_flow,
     interactive_workspace_piecharts,
     interactive_waterfall,
 )
@@ -145,6 +146,15 @@ def interactive_taskflow():
     fig = interactive_monthly_task_flow(analysis_global)
     div = _fig_to_div(fig)
     return render_template('interactive/taskflow.html', plot_div=div)
+
+
+@app.route('/interactive/taskflow_weekly')
+def interactive_taskflow_weekly():
+    if analysis_global is None or df_global is None:
+        _load_data()
+    fig = interactive_weekly_task_flow(analysis_global)
+    div = _fig_to_div(fig)
+    return render_template('interactive/taskflow_weekly.html', plot_div=div)
 
 
 @app.route('/interactive/workspace')

--- a/app/templates/interactive/index.html
+++ b/app/templates/interactive/index.html
@@ -5,6 +5,7 @@
 <div class="list-group">
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_ttc') }}">Time to Completion Histogram</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_taskflow') }}">Monthly Task Flow</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_taskflow_weekly') }}">Weekly Task Flow</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_workspace') }}">Workspace Distribution</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_waterfall_route') }}">Task Waterfall</a>
 </div>

--- a/app/templates/interactive/taskflow_weekly.html
+++ b/app/templates/interactive/taskflow_weekly.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Weekly Task Flow{% endblock %}
+{% block content %}
+<h1 class="mt-4 mb-4">Weekly Task Flow</h1>
+{{ plot_div|safe }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `interactive_weekly_task_flow` in `src/report.py`
- expose new `/interactive/taskflow_weekly` route
- add Weekly Task Flow template and navigation entry
- document the new feature in README

## Testing
- `python -m py_compile src/report.py app/app.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6859a61a09348330b11e59cb88512b36