### PR TITLE
Add weekly time summary interactive visualization

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -27,6 +27,7 @@ from src.report import (
     plot_liberal_stuff_done_heatmaps,
     interactive_ttc_histogram,
     interactive_monthly_task_flow,
+    interactive_weekly_time_minutes,
     interactive_workspace_piecharts,
     interactive_waterfall,
 )
@@ -145,6 +146,15 @@ def interactive_taskflow():
     fig = interactive_monthly_task_flow(analysis_global)
     div = _fig_to_div(fig)
     return render_template('interactive/taskflow.html', plot_div=div)
+
+
+@app.route('/interactive/time-minutes')
+def interactive_time_minutes():
+    if df_global is None:
+        _load_data()
+    fig = interactive_weekly_time_minutes(df_global)
+    div = _fig_to_div(fig)
+    return render_template('interactive/time_minutes.html', plot_div=div)
 
 
 @app.route('/interactive/workspace')

--- a/app/templates/interactive/index.html
+++ b/app/templates/interactive/index.html
@@ -5,6 +5,7 @@
 <div class="list-group">
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_ttc') }}">Time to Completion Histogram</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_taskflow') }}">Monthly Task Flow</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_time_minutes') }}">Weekly Task Time (Minutes)</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_workspace') }}">Workspace Distribution</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_waterfall_route') }}">Task Waterfall</a>
 </div>

--- a/app/templates/interactive/time_minutes.html
+++ b/app/templates/interactive/time_minutes.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Weekly Time (Minutes){% endblock %}
+{% block content %}
+<h1 class="mt-4 mb-4">Weekly Task Time (Minutes)</h1>
+{{ plot_div|safe }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- parse new Estimated and Actual time columns when loading Notion exports
- add a weekly interactive chart that sums estimated creation minutes and actual completion minutes
- expose the new chart in the interactive UI

## Testing
- python -m compileall src app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc43035dc8330b231fec8b54c859b)