### PR TITLE
Fix weekly minutes visualization and add weekly task flow counts view

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -28,6 +28,7 @@ from src.report import (
     interactive_ttc_histogram,
     interactive_monthly_task_flow,
     interactive_weekly_time_minutes,
+    interactive_weekly_task_flow_counts,
     interactive_workspace_piecharts,
     interactive_waterfall,
 )
@@ -155,6 +156,15 @@ def interactive_time_minutes():
     fig = interactive_weekly_time_minutes(df_global)
     div = _fig_to_div(fig)
     return render_template('interactive/time_minutes.html', plot_div=div)
+
+
+@app.route('/interactive/taskflow-weekly')
+def interactive_taskflow_weekly():
+    if df_global is None:
+        _load_data()
+    fig = interactive_weekly_task_flow_counts(df_global)
+    div = _fig_to_div(fig)
+    return render_template('interactive/taskflow_weekly.html', plot_div=div)
 
 
 @app.route('/interactive/workspace')

--- a/app/templates/interactive/index.html
+++ b/app/templates/interactive/index.html
@@ -2,11 +2,12 @@
 {% block title %}Interactive{% endblock %}
 {% block content %}
 <h1 class="mt-4 mb-4">Interactive Graphs</h1>
-<div class="list-group">
-  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_ttc') }}">Time to Completion Histogram</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_taskflow') }}">Monthly Task Flow</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_time_minutes') }}">Weekly Task Time (Minutes)</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_workspace') }}">Workspace Distribution</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_waterfall_route') }}">Task Waterfall</a>
-</div>
+  <div class="list-group">
+    <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_ttc') }}">Time to Completion Histogram</a>
+    <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_taskflow') }}">Monthly Task Flow</a>
+    <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_time_minutes') }}">Weekly Task Time (Minutes)</a>
+    <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_taskflow_weekly') }}">Weekly Task Flow (Counts)</a>
+    <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_workspace') }}">Workspace Distribution</a>
+    <a class="list-group-item list-group-item-action" href="{{ url_for('interactive_waterfall_route') }}">Task Waterfall</a>
+  </div>
 {% endblock %}

--- a/app/templates/interactive/taskflow_weekly.html
+++ b/app/templates/interactive/taskflow_weekly.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Weekly Task Flow (Counts){% endblock %}
+{% block content %}
+<h1 class="mt-4 mb-4">Weekly Task Flow (Counts)</h1>
+{{ plot_div|safe }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- fix the weekly minutes chart by preserving the week_start column after resetting the index
- add a weekly task flow (counts) plotly figure and expose it through a new interactive route
- update the interactive index with a link to the new view and template

## Testing
- python -m compileall src app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc81415dc833087ca698ff2ab99d1)