### PR TITLE
Add daily backlog waterfall to time minutes view

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -30,6 +30,7 @@ from src.report import (
     interactive_weekly_time_minutes,
     interactive_weekly_task_flow_counts,
     interactive_workspace_piecharts,
+    interactive_daily_time_backlog,
     interactive_waterfall,
 )
 app = Flask(__name__, static_folder="static", template_folder="templates")
@@ -153,9 +154,15 @@ def interactive_taskflow():
 def interactive_time_minutes():
     if df_global is None:
         _load_data()
-    fig = interactive_weekly_time_minutes(df_global)
-    div = _fig_to_div(fig)
-    return render_template('interactive/time_minutes.html', plot_div=div)
+    weekly_fig = interactive_weekly_time_minutes(df_global)
+    backlog_fig = interactive_daily_time_backlog(df_global)
+    weekly_div = _fig_to_div(weekly_fig)
+    backlog_div = _fig_to_div(backlog_fig)
+    return render_template(
+        'interactive/time_minutes.html',
+        weekly_div=weekly_div,
+        backlog_div=backlog_div,
+    )
 
 
 @app.route('/interactive/taskflow-weekly')

--- a/app/templates/interactive/time_minutes.html
+++ b/app/templates/interactive/time_minutes.html
@@ -2,5 +2,9 @@
 {% block title %}Weekly Time (Minutes){% endblock %}
 {% block content %}
 <h1 class="mt-4 mb-4">Weekly Task Time (Minutes)</h1>
-{{ plot_div|safe }}
+{{ weekly_div|safe }}
+
+<h2 class="mt-5 mb-3">Daily Backlog (Minutes)</h2>
+<p class="text-muted">Incoming tasks add estimated minutes while completed tasks subtract actual minutes, showing how the backlog shifts each day.</p>
+{{ backlog_div|safe }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- render both the weekly time-minutes bars and a new daily backlog waterfall on the interactive time-minutes page
- compute daily backlog minutes from estimated and actual times with a cumulative view
- reuse normalized status handling when aggregating task minutes

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fca1864848330b8633a7b7dc8da92)