### PR TITLE
Fix timezone-aware workspace filtering

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -255,8 +255,10 @@ def dashboard():
     # Workspace Focus (last 30 days)
     if not df_global.empty:
         df_workspace = df_global.copy()
-        df_workspace['Created time'] = pd.to_datetime(df_workspace['Created time'], errors='coerce')
-        cutoff_date = datetime.now() - timedelta(days=30)
+        df_workspace['Created time'] = pd.to_datetime(
+            df_workspace['Created time'], errors='coerce', utc=True
+        )
+        cutoff_date = pd.Timestamp.now(tz='UTC') - pd.Timedelta(days=30)
         recent_workspace = df_workspace[df_workspace['Created time'] >= cutoff_date]
         if recent_workspace.empty:
             recent_workspace = df_workspace


### PR DESCRIPTION
## Summary
- ensure the dashboard workspace filtering parses Created time values with UTC awareness
- compare against a timezone-aware cutoff date to avoid pandas invalid comparison errors

## Testing
- python -m compileall app/app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd1939b98833082a28f674f1d0f7f)