### PR TITLE
Fix flow streak iteration over daily backlog values

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -411,7 +411,9 @@ def dashboard():
     # Flow Streak
     if not daily_backlog.empty:
         streak = 0
-        for change in reversed(daily_backlog.sort_values('date')['net_change']):
+        for change in reversed(
+            daily_backlog.sort_values('date')['net_change'].tolist()
+        ):
             if change <= 0:
                 streak += 1
             else:


### PR DESCRIPTION
## Summary
- iterate over daily backlog net changes as a list to avoid index-based KeyErrors when reversing the series

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fd977ad7c8330ba56b4ab76e66be0)