### PR TITLE
Fix timezone-aware detection in _as_naive

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -132,7 +132,7 @@ def _get_timeframe_bounds(range_key: str) -> Tuple[Optional[pd.Timestamp], pd.Ti
 
 def _as_naive(series: pd.Series) -> pd.Series:
     converted = pd.to_datetime(series, errors="coerce")
-    if pd.api.types.is_datetime64tz_dtype(converted.dtype):
+    if isinstance(converted.dtype, pd.DatetimeTZDtype):
         converted = converted.dt.tz_localize(None)
     return converted
 


### PR DESCRIPTION
## Summary
- replace the deprecated timezone-aware datetime dtype check in `_as_naive`

## Testing
- flask --app app.app run *(fails: Missing Notion credentials)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910afe25380833099a2eb80af0681eb)