### PR TITLE
Fix integer formatting for weekly metrics aggregations

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -509,8 +509,14 @@ def _format_number(value, unit=""):
 def _format_delta(value, unit="", invert=False):
     if value is None:
         return {"text": "", "is_positive": False}
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
     sign = "" if value < 0 else "+"
-    text = f"{sign}{value:,.1f}{unit}" if isinstance(value, float) else f"{sign}{int(value)}{unit}"
+    text = (
+        f"{sign}{value:,.1f}{unit}"
+        if isinstance(value, float)
+        else f"{sign}{int(value)}{unit}"
+    )
     is_positive = value >= 0
     if invert:
         is_positive = not is_positive

--- a/src/report.py
+++ b/src/report.py
@@ -838,6 +838,12 @@ def prepare_weekly_time_minutes(df):
     weekly = weekly.sort_index()
     weekly.index.name = "week_start"
     weekly = weekly.reset_index()
+    if not weekly.empty:
+        weekly[["estimated_minutes", "actual_minutes"]] = (
+            weekly[["estimated_minutes", "actual_minutes"]]
+            .round()
+            .astype(int)
+        )
     weekly["label"] = weekly["week_start"].dt.strftime("%Y-%m-%d")
     weekly["year"] = weekly["week_start"].dt.year
 
@@ -1058,6 +1064,12 @@ def prepare_weekly_task_flow_counts(df):
     weekly = weekly.sort_index()
     weekly.index.name = "week_start"
     weekly = weekly.reset_index()
+    if not weekly.empty:
+        weekly[["tasks_created", "tasks_done"]] = (
+            weekly[["tasks_created", "tasks_done"]]
+            .round()
+            .astype(int)
+        )
     weekly["label"] = weekly["week_start"].dt.strftime("%Y-%m-%d")
     weekly["year"] = weekly["week_start"].dt.year
 


### PR DESCRIPTION
## Summary
- cast weekly time and task aggregations back to integers before returning dataframes
- treat integral float values as integers when formatting delta badge labels

## Testing
- python -m compileall src app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910afe55a30833095e7ec9bbbd5439f)