### PR TITLE
Refine workspace focus to use minutes

### DIFF
--- a/app/templates/interactive/workspace.html
+++ b/app/templates/interactive/workspace.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
-{% block title %}Workspace Distribution{% endblock %}
+{% block title %}Workspace Minutes{% endblock %}
 {% block content %}
-<h1 class="mt-4 mb-4">Workspace Distribution</h1>
+<h1 class="mt-4 mb-4">Workspace Minutes</h1>
 {{ plot_div|safe }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add helpers that aggregate estimated and actual minutes per workspace and expose a stacked bar chart
- switch the dashboard workspace focus card to use the minutes data for its KPI and visualization
- update the interactive workspace view to show the minutes-based chart

## Testing
- python -m compileall app src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910afe722748330ae146cc91062325d)