### PR TITLE
Include overlapping weeks when filtering dashboard timeframes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -160,13 +160,22 @@ def _filter_dataframe_for_timeframe(
 
 
 def _trim_timeframe(
-    df: pd.DataFrame, column: str, start_date: Optional[pd.Timestamp]
+    df: pd.DataFrame,
+    column: str,
+    start_date: Optional[pd.Timestamp],
+    *,
+    grace: Optional[pd.Timedelta] = None,
 ) -> pd.DataFrame:
     if start_date is None or df.empty or column not in df.columns:
         return df
 
     values = _as_naive(df[column])
-    trimmed = df.loc[values >= start_date].copy()
+    comparison = values
+    if grace is not None:
+        comparison = comparison + grace
+
+    mask = comparison >= start_date
+    trimmed = df.loc[mask].copy()
     return trimmed
 
 
@@ -227,10 +236,16 @@ def dashboard():
     df_filtered = _filter_dataframe_for_timeframe(df_global.copy(), start_date)
 
     weekly_minutes = _trim_timeframe(
-        prepare_weekly_time_minutes(df_filtered), 'week_start', start_date
+        prepare_weekly_time_minutes(df_filtered),
+        'week_start',
+        start_date,
+        grace=pd.Timedelta(days=6),
     )
     weekly_counts = _trim_timeframe(
-        prepare_weekly_task_flow_counts(df_filtered), 'week_start', start_date
+        prepare_weekly_task_flow_counts(df_filtered),
+        'week_start',
+        start_date,
+        grace=pd.Timedelta(days=6),
     )
     daily_backlog = _trim_timeframe(
         prepare_daily_time_backlog(df_filtered), 'date', start_date


### PR DESCRIPTION
## Summary
- allow `_trim_timeframe` to use an optional grace period so weekly aggregates keep overlapping weeks
- apply the overlap-aware filter to weekly time and task flow charts to keep them aligned with KPI tables

## Testing
- python -m compileall app src
- python - <<'PY'
import pandas as pd
from src.report import (
    interactive_weekly_time_minutes,
    interactive_weekly_task_flow_counts,
)

rows = [
    {
        "Created time": "2023-12-31 10:00",
        "Last edited": "2024-01-01 09:00",
        "Estimated Time (min)": 60,
        "Actual time (min)": 45,
        "Status": "Done",
    },
    {
        "Created time": "2024-03-31 11:00",
        "Last edited": "2024-04-02 08:30",
        "Estimated Time (min)": 90,
        "Actual time (min)": 85,
        "Status": "Done",
    },
    {
        "Created time": "2024-04-05 13:00",
        "Last edited": "2024-04-06 15:00",
        "Estimated Time (min)": 30,
        "Actual time (min)": 20,
        "Status": "In Progress",
    },
]

df = pd.DataFrame(rows)

qtd_start = pd.Timestamp('2024-04-01')
ytd_start = pd.Timestamp('2024-01-01')

qtd_minutes_fig = interactive_weekly_time_minutes(df, start_date=qtd_start)
qtd_counts_fig = interactive_weekly_task_flow_counts(df, start_date=qtd_start)
ytd_minutes_fig = interactive_weekly_time_minutes(df, start_date=ytd_start)
ytd_counts_fig = interactive_weekly_task_flow_counts(df, start_date=ytd_start)

print("QTD weekly minutes labels:", list(qtd_minutes_fig.data[0].x))
print("QTD weekly counts labels:", list(qtd_counts_fig.data[0].x))
print("YTD weekly minutes labels:", list(ytd_minutes_fig.data[0].x))
print("YTD weekly counts labels:", list(ytd_counts_fig.data[0].x))
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910afdb920483308fc3602a81d82d52)